### PR TITLE
unique string name

### DIFF
--- a/prisma/migrations/20231130070747_unique_tennis_string_from_name_brand_id/migration.sql
+++ b/prisma/migrations/20231130070747_unique_tennis_string_from_name_brand_id/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name,brand_id]` on the table `TennisString` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "TennisString_name_brand_id_key" ON "TennisString"("name", "brand_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,7 +29,7 @@ model Review {
   string    TennisString @relation(fields: [string_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   created_at DateTime @default(now())
-  updated_at DateTime @updatedAt @default(now())
+  updated_at DateTime @default(now()) @updatedAt
 
   @@unique([user_id, string_id])
 }
@@ -42,6 +42,8 @@ model TennisString {
   Brand       Brand    @relation(fields: [brand_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
   brand_id    String
   Review      Review[]
+
+  @@unique([name, brand_id])
 }
 
 model Brand {

--- a/src/lib/components/forms/string_form.svelte
+++ b/src/lib/components/forms/string_form.svelte
@@ -9,16 +9,19 @@
 	export let brands: Brand[];
 	export let data: SuperValidated<StringFormSchema>;
 
-	const { form, enhance, constraints, message } = superForm(data);
-	const materials = ['polyester', 'multifilament', 'natural gut', 'synthetic gut'];
-
 	const toast = getToastStore();
-	$: if ($message) {
-		toast.trigger({
-			message: $message,
-			background: 'variant-filled-error'
-		});
-	}
+
+	const { form, enhance, constraints, message } = superForm(data, {
+		onUpdated({ form }) {
+			if (form.message) {
+				toast.trigger({
+					message: $message,
+					background: 'variant-filled-error'
+				});
+			}
+		}
+	});
+	const materials = ['polyester', 'multifilament', 'natural gut', 'synthetic gut'];
 </script>
 
 <form use:enhance method="POST" class="flex flex-col gap-4">

--- a/src/lib/components/forms/string_form.svelte
+++ b/src/lib/components/forms/string_form.svelte
@@ -4,12 +4,21 @@
 	import { superForm } from 'sveltekit-superforms/client';
 	import { page } from '$app/stores';
 	import type { StringFormSchema } from '$lib/form_schemas';
+	import { getToastStore } from '@skeletonlabs/skeleton';
 
 	export let brands: Brand[];
 	export let data: SuperValidated<StringFormSchema>;
 
-	const { form, enhance, constraints } = superForm(data);
+	const { form, enhance, constraints, message } = superForm(data);
 	const materials = ['polyester', 'multifilament', 'natural gut', 'synthetic gut'];
+
+	const toast = getToastStore();
+	$: if ($message) {
+		toast.trigger({
+			message: $message,
+			background: 'variant-filled-error'
+		});
+	}
 </script>
 
 <form use:enhance method="POST" class="flex flex-col gap-4">

--- a/src/routes/(protected)/strings/[id]/update/+page.server.ts
+++ b/src/routes/(protected)/strings/[id]/update/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
-import { superValidate } from 'sveltekit-superforms/server';
+import { message, superValidate } from 'sveltekit-superforms/server';
 import type { Brand } from '@prisma/client';
 import { string_schema } from '$lib/form_schemas';
 
@@ -51,9 +51,12 @@ export const actions = {
 		} catch (err) {
 			console.error(err);
 			if (err instanceof Error) {
-				return fail(500, { message: err.message });
+				if (err.message.includes('Unique constraint failed on the fields: (`name`,`brand_id`)')) {
+					return message(form, 'A string with this name already exists');
+				}
+				return message(form, err.message);
 			} else {
-				return fail(500, { message: 'Unknown error' });
+				return message(form, 'Unknown error');
 			}
 		}
 	}

--- a/src/routes/(protected)/strings/add/+page.server.ts
+++ b/src/routes/(protected)/strings/add/+page.server.ts
@@ -1,6 +1,6 @@
 import type { Brand, TennisString } from '@prisma/client';
 import { fail, redirect } from '@sveltejs/kit';
-import { superValidate } from 'sveltekit-superforms/server';
+import { message, superValidate } from 'sveltekit-superforms/server';
 import type { Actions, PageServerLoad } from './$types';
 import { string_schema } from '$lib/form_schemas';
 
@@ -46,9 +46,12 @@ export const actions = {
 		} catch (err) {
 			console.error(err);
 			if (err instanceof Error) {
-				return fail(500, { message: err.message });
+				if (err.message.includes('Unique constraint failed on the fields: (`name`,`brand_id`)')) {
+					return message(form, 'A string with this name already exists');
+				}
+				return message(form, err.message);
 			} else {
-				return fail(500, { message: 'Unknown error' });
+				return message(form, 'Unknown error');
 			}
 		}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,14 @@
 	import '../app.postcss';
 	import type { PageData } from './$types';
 	import { computePosition, autoUpdate, flip, shift, offset, arrow } from '@floating-ui/dom';
-	import { AppShell, Drawer, Modal, initializeStores, storePopup } from '@skeletonlabs/skeleton';
+	import {
+		AppShell,
+		Drawer,
+		Modal,
+		Toast,
+		initializeStores,
+		storePopup
+	} from '@skeletonlabs/skeleton';
 	import Header from '$lib/components/header.svelte';
 	import NavigationLinks from '$lib/components/navigation_links.svelte';
 
@@ -15,7 +22,7 @@
 <Drawer>
 	<NavigationLinks />
 </Drawer>
-
+<Toast />
 <Modal />
 
 <AppShell slotSidebarLeft="p-4 w-0 md:w-64" scrollbarGutter="auto">


### PR DESCRIPTION
- feat(tennis-string): ✨ unique string name and brand id combos
- chore: 🔧 generate migrations
- refactor(string): ♻️ handle erros via message and toasts
- refactor(string-form): ♻️ handle toast through superform onupdated
